### PR TITLE
Feature/initial migrations

### DIFF
--- a/travel-api/database/migrations/2024_08_28_134638_create_roles_table.php
+++ b/travel-api/database/migrations/2024_08_28_134638_create_roles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/travel-api/database/migrations/2024_08_28_135225_create_role_user_table.php
+++ b/travel-api/database/migrations/2024_08_28_135225_create_role_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('role_id');
+            $table->unsignedBigInteger('user_id');
+            $table->timestamps();
+
+            $table->foreign('role_id')->references('id')->on('roles');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('role_user');
+    }
+};

--- a/travel-api/database/migrations/2024_08_28_135604_create_travels_table.php
+++ b/travel-api/database/migrations/2024_08_28_135604_create_travels_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('travels', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('is_public')->default(true);
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->text('description');
+            $table->integer('number_of_days');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('travels');
+    }
+};

--- a/travel-api/database/migrations/2024_08_28_135834_create_tours_table.php
+++ b/travel-api/database/migrations/2024_08_28_135834_create_tours_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tours', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('travel_id');
+            $table->string('name');
+            $table->date('starting_date');
+            $table->date('ending_date');
+            $table->integer('price');
+            $table->timestamps();
+
+            $table->foreign('travel_id')->references('id')->on('travels');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tours');
+    }
+};

--- a/travel-api/database/migrations/2024_08_29_002912_add_check_tour_dates_trigger_on_tours_table.php
+++ b/travel-api/database/migrations/2024_08_29_002912_add_check_tour_dates_trigger_on_tours_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        DB::unprepared('
+            CREATE TRIGGER check_tour_dates_before_insert_on_tours
+            BEFORE INSERT ON tours
+            FOR EACH ROW
+            BEGIN
+                DECLARE travel_days INT;
+                DECLARE date_diff INT;
+
+                SELECT number_of_days INTO travel_days FROM travels WHERE id = NEW.travel_id;
+                SET date_diff = DATEDIFF(NEW.ending_date, NEW.starting_date);
+
+                IF date_diff != travel_days THEN
+                    SIGNAL SQLSTATE "45000" SET MESSAGE_TEXT = "Inconsistent tour dates with travel number of days";
+                END IF;
+            END;
+        ');
+
+        DB::unprepared('
+            CREATE TRIGGER check_tour_dates_before_update_on_tours
+            BEFORE UPDATE ON tours
+            FOR EACH ROW
+            BEGIN
+                DECLARE travel_days INT;
+                DECLARE date_diff INT;
+
+                SELECT number_of_days INTO travel_days FROM travels WHERE id = NEW.travel_id;
+                SET date_diff = DATEDIFF(NEW.ending_date, NEW.starting_date);
+
+                IF date_diff != travel_days THEN
+                    SIGNAL SQLSTATE "45000" SET MESSAGE_TEXT = "Inconsistent tour dates with travel number of days";
+                END IF;
+            END;
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        DB::unprepared('DROP TRIGGER IF EXISTS check_tour_dates_before_insert_on_tours');
+        DB::unprepared('DROP TRIGGER IF EXISTS check_tour_dates_before_update_on_tours');
+    }
+};

--- a/travel-api/database/migrations/2024_08_29_002943_add_format_price_trigger_on_tours_table.php
+++ b/travel-api/database/migrations/2024_08_29_002943_add_format_price_trigger_on_tours_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::unprepared('
+            CREATE TRIGGER format_price_before_insert_on_tours
+            BEFORE INSERT ON tours
+            FOR EACH ROW
+            BEGIN
+                SET NEW.price = NEW.price * 100;
+            END
+        ');
+
+        DB::unprepared('
+            CREATE TRIGGER format_price_before_update_on_tours
+            BEFORE UPDATE ON tours
+            FOR EACH ROW
+            BEGIN
+                SET NEW.price = NEW.price * 100;
+            END
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared('DROP TRIGGER IF EXISTS format_price_before_insert_on_tours');
+    }
+};


### PR DESCRIPTION
## Initial Migrations

### Description
 Migrations to create the initial structure of the database (users, roles, travels, tours).
 
### Notes
- Two migrations are specific for adding triggers to to the database to enforce business rules and logical consistency:
  - Price of tours must be saved as 'price * 100' - in the frontend '99900' will be showed as '999.00'.
  - The difference between the dates of tours cannot be inconsistent to the number of days of the related travel (e.g: travels has duration of 3 days? the starting and ending date of a tour related cannot be '11/08/2007' and '21/08/2007', respectively).
