### PR TITLE
Feature/user admin also editor enforcement

### DIFF
--- a/travel-api/app/Models/User.php
+++ b/travel-api/app/Models/User.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -48,5 +50,18 @@ class User extends Authenticatable
 
     public function roles(): BelongsToMany {
         return $this->belongsToMany(Role::class);
+    }
+
+    public function assignRole($role) {
+        $admin_role = Role::where('name', 'admin')->first();
+
+        // an admin is always also an editor
+        if ($role->name === $admin_role->name) {
+            $editor_role = Role::where('name', 'editor')->first();
+
+            $this->roles()->attach($editor_role);
+        }
+
+        $this->roles()->attach($role);
     }
 }

--- a/travel-api/database/migrations/2024_08_28_135225_create_role_user_table.php
+++ b/travel-api/database/migrations/2024_08_28_135225_create_role_user_table.php
@@ -12,13 +12,14 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('role_user', function (Blueprint $table) {
-            $table->id();
             $table->unsignedBigInteger('role_id');
             $table->unsignedBigInteger('user_id');
             $table->timestamps();
 
             $table->foreign('role_id')->references('id')->on('roles');
             $table->foreign('user_id')->references('id')->on('users');
+
+            $table->primary(['role_id', 'user_id']);
         });
     }
 

--- a/travel-api/database/seeders/TestDatabaseSeeder.php
+++ b/travel-api/database/seeders/TestDatabaseSeeder.php
@@ -5,8 +5,11 @@ namespace Database\Seeders;
 use App\Models\Role;
 use App\Models\User;
 use Illuminate\Database\Seeder;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\TourSeeder;
+use Database\Seeders\TravelSeeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
 class TestDatabaseSeeder extends Seeder
 {
@@ -22,18 +25,7 @@ class TestDatabaseSeeder extends Seeder
         foreach ($users as $user) {
             $role = Role::inRandomOrder()->first();
 
-            if ($role->name === 'admin') {
-                DB::table('role_user')->insert([ // implement this logic of associating an 'admin' role to a user automatically associates an 'editor' role to them in a trigger.
-                    'role_id' => Role::where('name', 'editor')->first()->id,
-                    'user_id' => $user->id
-                ]);
-            }
-
-            DB::table('role_user')->insert([
-                'role_id' => $role->id,
-                'user_id' => $user->id
-            ]);
-
+            $user->assignRole($role);
         }
 
     }

--- a/travel-api/tests/Feature/UserTest.php
+++ b/travel-api/tests/Feature/UserTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\RoleUser;
+use Tests\TestCase;
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A basic feature test example.
+     */
+    public function test_admin_user_is_also_editor(): void
+    {
+        $this->seed(RoleSeeder::class);
+        $user = User::factory()->create();
+        $admin_role = Role::where('name', 'admin')->first();
+        $editor_role = Role::where('name', 'editor')->first();
+
+        $user->assignRole($admin_role);
+
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $user->id,
+            'role_id' => $admin_role->id,
+        ]);
+
+        $this->assertDatabaseHas('role_user', [
+            'user_id' => $user->id,
+            'role_id' => $editor_role->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Enforce User Admin to Also Be an Editor
### Description
 The business rule for making all admins also editors have been enforced.
 
### Notes
- A method 'assignRole' has been added to User model to be used to apply roles instead of an approach involving DB::insert, $user->attach() and observers or listeners/events. There the this rule is enforced, and every place in the application where the enforcement was made other way have been changed.
- The primary key in 'role_user' has been changed to be a composite pk from user_id and role_id.
- Added 'UserTest' class with a test for this business rule.