### PR TITLE
Feature/filtering and sorting in tours index endpoint

### DIFF
--- a/travel-api/app/Http/Controllers/Api/V1/TourController.php
+++ b/travel-api/app/Http/Controllers/Api/V1/TourController.php
@@ -14,10 +14,18 @@ class TourController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index($travel_slug)
-    {
-        $travel = Travel::where('slug', $travel_slug)->first();
-        $tours = Tour::where('travel_id', $travel->id)->paginate(10);
+    public function index(Travel $travel, Request $request) {
+        $query = $travel->tours()->getQuery();
+
+        $request['price_from'] && $query->where('price', '>=', $request['price_from'] * 100);
+        $request['price_to'] && $query->where('price', '<=', $request['price_to'] * 100);
+        $request['date_from'] && $query->where('starting_date', '>=', $request['date_from']);
+        $request['date_to'] && $query->where('ending_date', '<=', $request['date_to']);
+        $request['sort_by_price'] && $query->orderBy('price', $request['sort_by_price']);
+
+        $tours = $query
+        ->orderBy('starting_date')
+        ->paginate(10);
 
         return TourResource::collection($tours);
     }

--- a/travel-api/app/Http/Resources/TourResource.php
+++ b/travel-api/app/Http/Resources/TourResource.php
@@ -19,7 +19,7 @@ class TourResource extends JsonResource
             'name' => $this->name,
             'starting_date' => $this->starting_date,
             'ending_date' => $this->ending_date,
-            'price' => $this->price,
+            'price' => number_format($this->price, 2),
         ];
     }
 }


### PR DESCRIPTION
## Filtering and Sorting in Tours Index Endpoint
### Description
 The endpoint to get tours by travel slug now allows for series of filtering/sorting options:
  - filter by price and starting_date (from-to), and sorting by price/starting_date (starting_date always by default: user don't need to specify it).
  
### Notes
- Tests added to check for filterings and sortings.