### PR TITLE
Feature/update travel endpoint

### DIFF
--- a/travel-api/app/Http/Controllers/Api/V1/TravelController.php
+++ b/travel-api/app/Http/Controllers/Api/V1/TravelController.php
@@ -6,6 +6,7 @@ use App\Models\Travel;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreTravelRequest;
+use App\Http\Requests\UpdateTravelRequest;
 use App\Http\Resources\TravelResource;
 
 class TravelController extends Controller
@@ -57,9 +58,13 @@ class TravelController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(UpdateTravelRequest $request, Travel $travel)
     {
-        //
+        $travel->update($request->validated());
+
+        $travel->refresh();
+
+        return new TravelResource($travel);
     }
 
     /**

--- a/travel-api/app/Http/Requests/UpdateTravelRequest.php
+++ b/travel-api/app/Http/Requests/UpdateTravelRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class UpdateTravelRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->roles()->where('name', 'editor')->exists();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'is_public' => ['sometimes', 'required', 'boolean'],
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'description' => ['sometimes', 'required', 'string', 'max:65535'],
+            'number_of_days' => ['sometimes', 'required', 'integer']
+        ];
+    }
+
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json([
+            'success' => false,
+            'status' => 422,
+            'message' => 'Validation errors',
+            'data' => $validator->errors()
+        ], 422));
+    }
+}

--- a/travel-api/routes/api_v1.php
+++ b/travel-api/routes/api_v1.php
@@ -10,3 +10,4 @@ Route::post('/travels', [TravelController::class, 'store'])->middleware('auth:sa
 Route::get('/travels/{travel:slug}/tours', [TourController::class, 'index'])->name('api_v1.tour.index');
 Route::post('/create-user', CreateUserController::class)->middleware('auth:sanctum')->name('api_v1.create_user');
 Route::post('/travels/{travel}/tour', [TourController::class, 'store'])->middleware('auth:sanctum')->name('api_v1.tour.store');
+Route::put('/travels/{travel}', [TravelController::class, 'update'])->middleware('auth:sanctum')->name('api_v1.travel.update');

--- a/travel-api/tests/Feature/TravelTest.php
+++ b/travel-api/tests/Feature/TravelTest.php
@@ -29,16 +29,19 @@ class TravelTest extends TestCase
     }
 
     public function test_public_paginated_travels_are_returned(): void {
-        $travels = Travel::factory()->count(15)->create();
-        $publicTravels = $travels->filter(fn($travel) => $travel->is_public);
-        $expectedResponseData = TravelResource::collection($publicTravels)->resolve();
+        $privateTravels = Travel::factory()->count(5)->create(['is_public' => false]);
+        $publicTravels = Travel::factory()->count(5)->create(['is_public' => true]);
+        // $expectedResponseData = TravelResource::collection($publicTravels)->resolve();
 
         $response = $this->get(route('api_v1.travel.index'));
 
         $response->assertStatus(200);
         $response->assertJsonPath('meta.per_page', 10);
         $response->assertJsonPath('meta.total', count($publicTravels));
-        $response->assertJson(['data' => $expectedResponseData]);
+        foreach ($publicTravels as $publicTravel) {
+            $response->assertJsonFragment(['name' => $publicTravel->name]);
+        }
+        // $response->assertJson(['data' => $expectedResponseData]);
     }
 
     function test_it_can_be_created_by_admin(): void {


### PR DESCRIPTION
## Endpoint for Updating Travels
### Description
 An endpoint for editors to update travels
  
### Notes
- Tests included checking authentication, authorization and data validation.
- A fix has been made in a test i've discovered it was sometimes failing (public paginated travels are returned?):
  - The expected response data contained all the public travels, but since our pagination only allows 10 by page, whenever the public travels amount is greater than 10, the test fails: not all public travels are returned in the response, just the first 10.
  - Now it's determined exactly 10 travels to be created in the test, 5 non-public and 5 public, and the public ones are iterated over to see if they're present in the response (if the application is ok they'll ever be present: 5 is always less than 10, so they're in the same page, thus inside the json response).